### PR TITLE
HTML title: include page title

### DIFF
--- a/includes/head.html
+++ b/includes/head.html
@@ -6,7 +6,7 @@
     <meta name="author" content="">
     <link rel="shortcut icon" href="{{ site.baseurl }}/jekyll-common/assets/ico/favicon.ico">
 
-    <title>{{ site.title }}</title>
+    <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
 
     <link href="{{ site.baseurl }}/jekyll-common/assets/css/bootstrap.css" rel="stylesheet">
     <link href="{{ site.baseurl }}/jekyll-common/assets/css/bootstrap-theme.css" rel="stylesheet">


### PR DESCRIPTION
- Before, HTML title was just "site.title"
- Now, use "page.title - site.title", if page.title is defined
- I'm not sure if it's better to have page or site title first.  What
  do you think?